### PR TITLE
Small tweaks before pulling into warp repo

### DIFF
--- a/specs/while_loop.yaml
+++ b/specs/while_loop.yaml
@@ -1,6 +1,6 @@
 name: "While loop"
 tags: ["shell"]
-command: "while $CONDITION; do\n\t$COMMAND\ndone"
+command: "while {{condition}}; do\n\t{{command}}\ndone"
 arguments:
   -
     name: "condition"

--- a/workflows/Cargo.toml
+++ b/workflows/Cargo.toml
@@ -10,7 +10,7 @@ warp-workflows-types = {path = "../workflow-types" }
 anyhow = "1.0"
 convert_case = "0.4.0"
 memmap = "0.7.0"
-serde_yaml = "0.8.23"
+serde_yaml = "0.8"
 uneval = {git = "https://github.com/warpdotdev/uneval", rev = "df4d9fad372aedc447e6f93ca0f930fabaf9dd1a"}
 walkdir = "2.3.2"
 warp-workflows-types = {path = "../workflow-types" }


### PR DESCRIPTION
Fixing a few things I noticed while testing pulling this crate into the warp repo:

1) Add the correct escpaing for arguments within the yaml files
2) Pin serde yaml at a more generic version to avoid conflicts with the version we use in Warp