### PR TITLE
Remove builder pattern

### DIFF
--- a/workflow-types/Cargo.toml
+++ b/workflow-types/Cargo.toml
@@ -5,3 +5,4 @@ edition = "2021"
 
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}
+derive_builder = "0.10.2"

--- a/workflow-types/Cargo.toml
+++ b/workflow-types/Cargo.toml
@@ -5,4 +5,3 @@ edition = "2021"
 
 [dependencies]
 serde = {version = "1.0", features = ["derive"]}
-derive_builder = "0.10.2"

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -25,6 +25,7 @@ pub struct Workflow {
     #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
     #[serde(default)]
+    #[builder(default)]
     pub arguments: Vec<Argument>,
     #[builder(setter(into, strip_option), default)]
     pub source_url: Option<String>,

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -70,6 +70,25 @@ impl Workflow {
     pub fn shells(&self) -> &Vec<Shell> {
         &self.shells
     }
+
+    pub fn new(name: impl Into<String>, command: impl Into<String>) -> Self {
+        Workflow {
+            name: name.into(),
+            command: command.into(),
+            tags: vec![],
+            description: None,
+            arguments: vec![],
+            source_url: None,
+            author: None,
+            author_url: None,
+            shells: vec![]
+        }
+    }
+
+    pub fn with_arguments(mut self, arguments: Vec<Argument>) -> Self {
+        self.arguments = arguments;
+        self
+    }
 }
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
@@ -83,6 +102,18 @@ pub struct Argument {
 }
 
 impl Argument {
+    pub fn new(name: impl Into<String>) -> Self {
+        Argument {
+            description: None,
+            name: name.into(),
+        }
+    }
+
+    pub fn with_description(mut self, description: impl Into<String>) -> Self {
+        self.description = Some(description.into());
+        self
+    }
+
     pub fn name(&self) -> &str {
         &self.name
     }

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -1,3 +1,6 @@
+#[macro_use]
+extern crate derive_builder;
+
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -10,36 +13,29 @@ pub enum Shell {
     Zsh,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
     pub name: String,
     pub command: String,
+    #[serde(default)]
+    #[builder(default)]
     pub tags: Vec<String>,
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
     #[serde(default)]
     pub arguments: Vec<Argument>,
+    #[builder(setter(into, strip_option), default)]
     pub source_url: Option<String>,
+    #[builder(setter(into, strip_option), default)]
     pub author: Option<String>,
+    #[builder(setter(into, strip_option), default)]
     pub author_url: Option<String>,
     #[serde(default)]
+    #[builder(default)]
     pub shells: Vec<Shell>,
 }
 
 impl Workflow {
-    pub fn with_name_and_command(name: String, command: String) -> Self {
-        Self {
-            name,
-            tags: vec![],
-            command,
-            description: None,
-            arguments: vec![],
-            source_url: None,
-            author: None,
-            author_url: None,
-            shells: vec![],
-        }
-    }
-
     pub fn name(&self) -> &str {
         &self.name
     }
@@ -73,10 +69,12 @@ impl Workflow {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize)]
+#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 pub struct Argument {
     pub name: String,
+    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
+    #[builder(setter(into, strip_option), default)]
     pub default_value: Option<String>,
 }
 

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -1,6 +1,3 @@
-#[macro_use]
-extern crate derive_builder;
-
 use serde::{Deserialize, Serialize};
 
 #[derive(Clone, Debug, Deserialize, Serialize)]
@@ -13,28 +10,19 @@ pub enum Shell {
     Zsh,
 }
 
-#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
-    #[builder(setter(into))]
     pub name: String,
-    #[builder(setter(into))]
     pub command: String,
     #[serde(default)]
-    #[builder(default)]
     pub tags: Vec<String>,
-    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
     #[serde(default)]
-    #[builder(default)]
     pub arguments: Vec<Argument>,
-    #[builder(setter(into, strip_option), default)]
     pub source_url: Option<String>,
-    #[builder(setter(into, strip_option), default)]
     pub author: Option<String>,
-    #[builder(setter(into, strip_option), default)]
     pub author_url: Option<String>,
     #[serde(default)]
-    #[builder(default)]
     pub shells: Vec<Shell>,
 }
 
@@ -91,13 +79,10 @@ impl Workflow {
     }
 }
 
-#[derive(Builder, Clone, Debug, Deserialize, Serialize)]
+#[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct Argument {
-    #[builder(setter(into))]
     pub name: String,
-    #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,
-    #[builder(setter(into, strip_option), default)]
     pub default_value: Option<String>,
 }
 

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -106,6 +106,7 @@ impl Argument {
         Argument {
             description: None,
             name: name.into(),
+            default_value: None
         }
     }
 

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -15,7 +15,9 @@ pub enum Shell {
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 pub struct Workflow {
+    #[builder(setter(into))]
     pub name: String,
+    #[builder(setter(into))]
     pub command: String,
     #[serde(default)]
     #[builder(default)]
@@ -71,6 +73,7 @@ impl Workflow {
 
 #[derive(Builder, Clone, Debug, Deserialize, Serialize)]
 pub struct Argument {
+    #[builder(setter(into))]
     pub name: String,
     #[builder(setter(into, strip_option), default)]
     pub description: Option<String>,


### PR DESCRIPTION
It was overly complex and returning a `Result` was not ideal. I ended up creating a builder by hand instead.