### PR TITLE
Ensure build is run before publish

### DIFF
--- a/build_ts/package.json
+++ b/build_ts/package.json
@@ -1,11 +1,12 @@
 {
   "name": "warp-workflows",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Workflows used within Warp",
   "main": "dist/warp-workflows.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "build": "tsc && webpack"
+    "build": "tsc && webpack",
+    "prepare": "npm run build"
   },
   "author": "Warp Team (eng@warp.dev)",
   "license": "MIT",


### PR DESCRIPTION
Ensure the build script produces a compiled version of the workflow specs before publish. To do this we use the npm `prepare` [script](https://docs.npmjs.com/cli/v8/using-npm/scripts) to run `build` before the app is packaged. Ensure this works locally by pulling in the built npm package into commands.dev