### PR TITLE
Derive Hash + PartialOrd on Workflow struct

### DIFF
--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -1,6 +1,6 @@
 use serde::{Deserialize, Serialize};
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Hash, PartialOrd)]
 pub enum Shell {
     #[serde(rename(deserialize = "fish"))]
     Fish,
@@ -10,7 +10,7 @@ pub enum Shell {
     Zsh,
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Hash, PartialOrd)]
 pub struct Workflow {
     pub name: String,
     pub command: String,
@@ -79,7 +79,7 @@ impl Workflow {
     }
 }
 
-#[derive(Clone, Debug, Deserialize, Serialize, PartialEq)]
+#[derive(Clone, Debug, Deserialize, Serialize, PartialEq, Hash, PartialOrd)]
 pub struct Argument {
     pub name: String,
     pub description: Option<String>,


### PR DESCRIPTION
This is useful so that we can store Workflows in a HashSet within the Warp repo