### PR TITLE
Add token when checking out repo

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -18,7 +18,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
+        with:
+          token: ${{ secrets.GH_RUN_WORKFLOW_PAT }}
         # Install all dependencies
       - name: install
         run: npm --prefix build_ts/ install
@@ -30,7 +32,6 @@ jobs:
       - name: "Automated Version Bump"
         uses: "phips28/gh-action-bump-version@master"
         env:
-          # TODO: Validate this is the correct token
           GITHUB_TOKEN: ${{ secrets.GH_RUN_WORKFLOW_PAT }}
           PACKAGEJSON_DIR:  'build_ts'
           TARGET-BRANCH: 'main'


### PR DESCRIPTION
Further debugging to the GH action that is failing. My best guess is we should also check out the repo with the same token, since there may be inconsistency between how we check out versus how we push