### PR TITLE
Add documentation to workflows repo

### DIFF
--- a/FORMAT.md
+++ b/FORMAT.md
@@ -1,0 +1,78 @@
+# Workflows File Format
+
+The workflow file format is a [yaml](https://yaml.org/) file and must have either a `.yml ` or `yaml` extension. If you're new to YAML and want to learn more, see "[Learn YAML in Y minutes](https://learnxinyminutes.com/docs/yaml/)."
+
+
+_Compatibility Note_: Warp is still in Beta and this format is subject to change.
+
+###  `name`
+---
+The name of the Workflow. Required.
+
+### `command`
+----
+The command that is executed when the Workflow is selected. Required.
+
+### `tags`
+----
+An array of tags that are useful to categorize the Workflow. Optional.
+
+```yaml
+tags: ["git", "GitHub"]
+```
+
+### `description`
+----
+The description of the Workflow and what it does. Optional.
+
+### `source_url`
+----
+The URL from where the Workflow was originally generated from. This is surfaced in [commands.dev](https://www.commands.dev/) for attribution purposes. Optional.
+
+
+### `author`
+----
+The original author of the Workflow. For example, if this workflow was generated from StackOverflow, the `author` would be the `author` of the StackOverflow post. This is surfaced in [commands.dev](https://www.commands.dev/) for attribution purposes. Optional.
+
+### `author_url`
+----
+The URL of original author of the Workflow. For example, if this workflow was generated from StackOverflow, the `author_url` would be the StackOverflow author's profile page. This is surfaced in [commands.dev](https://www.commands.dev/) for attribution purposes. Optional.
+
+### `shells`
+----
+The list of shells where this Workflow is valid. If not specified, the Workflow is assumed to be valid in all shells. This must be one of `zsh`, `bash`, or  `fish`.
+
+
+## `arguments`
+----
+A Workflow can have parameterized arguments to specify pieces of the Workflow that need to be filled in by the user.
+
+You can specify which part of the Workflow command maps to an argument by surrounding it with two curly braces (`{{<argument>}}`).
+
+For example the workflow command:
+```bash
+for {{variable} in {{sequence}}}; do
+  {{command}}
+done
+```
+Includes 3 arguments: `variable`, `sequence`, and `command`.
+
+## `arguments.name` 
+-----
+The name of the argument. The argument name is used within the command to specify the ranges of the argument. Required.
+
+```yaml
+name: Example workflow
+command: echo {{string}}
+arguments:
+  - name: string
+  - description: The value to echo
+```
+
+## `arguments.description` 
+-----
+The description of the argument. This is surfaced in both commands.dev and Warp to help users fill in Workflow arguments. Optional
+
+## `arguments.default_value`
+-----
+The default value for the argument. If specified, the `default_value` replaces the argument name within the command. Optional

--- a/README.md
+++ b/README.md
@@ -1,90 +1,16 @@
-# [0] Overview and Mockups
-
-Entering commands in the terminal can be tedious and hard–developers often need to construct commands one argument and flag at a time, often using StackOverflow.
-
-Workflows (formerly called Tasks) make it easy to browse, search, execute and share commands (or a series of commands)--without needing to leave your terminal.
-
-Warp wants to make it easier to enter commands by launching with 100+ common workflows and an open-source file format--so devs can create private workflows for themselves or their team.
-
-Please comment with feedback, we’ll create an individual sub-thread for each mockup and memo section!
+# Workflows
+The repo for Workflows that appear within Warp and within [commands.dev](https://www.commands.dev/)
 
 
+## What are Workflows?
+Workflows are an easier way to execute and share commands within Warp. They are searchable by name, description, or command and are easily parameterized. 
 
-|[A] The Workflow’s menu.|
-|:--:|
-| ![A](https://user-images.githubusercontent.com/29553206/150206227-e5ae4eec-b322-4509-aba8-f67ee23eab39.png) |
+## How Do I Access Workflows?
+Workflows can be accessed within Warp directly within the app, either through the command palette or by pressing `ctrl-shift-r`. 
 
-|[B] Filling a Workflow in the Input Editor with the menu expanded.|
-|:--:|
-| ![B](https://user-images.githubusercontent.com/29553206/150206255-2288326d-4c5c-459a-b1fc-77c046c13bc7.png) |
+All public workflows (i.e. workflows within this repo) are also available at [commands.dev](https://www.commands.dev/).
 
-|[C] Filling a Workflow in the Input Editor with the menu collapsed and tab completion.|
-|:--:|
-| ![C](https://user-images.githubusercontent.com/29553206/150207821-d0d02b9f-686e-475a-b1fe-a3741fb3f707.png) |
+## Contributing
+Contributions are always welcome! If you have a workflow that would be useful to many Warp users, feel free to send a PR to add a Workflow spec.
 
-# [1] Pain Points and Goals
-
-Our team, tends to run into a few pain points when entering commands:
-
-1. We need to find a command but
-	1. the arguments and flags do not represent the task we are trying to perform
-		1. To “undo last git commit” -> `git reset --hard SOFT`
-	2. our team's playbook (guide) lives outside of the terminal 
-2. We can’t find aliases that other team members have made
-	1. No store to browse aliases
-	2. Sharing, revoking access, or updating aliases through version control is not straightforward, especially
-	   since aliases are global
-3. The shell does not provide enough documentation or UI to help enter parameters to commands
-
-# [2] How is this Different from Aliases?
-
-Power users tend to save aliases, create shell functions, and leverage CLI tools that streamline this.
-Aliases, however, have major pain points:
-
-1. need to context switch
-	1. leave vim, source dotfiles, or reset shell
-2. it’s difficult to attach documentation
-3. are not easily searchable or sharable
-4. are not easily parameterized
-
-Getting aliases and functions to a productive state requires an upfront investment that’s justifiable for devs who
-spend most of their workday in the terminal but less so for beginners and casual users.
-
-# [3] Workflows V1
-
-We’re planning on the first launch of Workflows to include:
-
-1. The ability to search and execute a workflow directly from the input editor
-2. The top 100 workflows across various commands already bundled
-   1. `git`, `sed`, and `grep`
-3. The ability for devs to create private workflows in an open-source file-format, including repo-specific workflows that live in a `.warp` directory
-4. The ability to create a workflow from a Block by right-clicking on it
-
-# [4] S/O Open Source Projects
-
-These are some of the open source projects that we’ve gotten inspiration from: [tldr;](https://github.com/tldr-pages/tldr) [cheat.sh](https://github.com/chubin/cheat.sh), [cheatsheets](https://github.com/rstacruz/cheatsheets), [navi](https://github.com/denisidoro/navi), [howdoi](https://github.com/gleitz/howdoi), [cheat](https://github.com/cheat/cheat), [how2](https://github.com/santinic/how2), [kb](https://github.com/gnebbia/kb), [eg](https://github.com/srsudar/eg).
-
-Navi [in particular!](https://github.com/denisidoro/navi/blob/master/docs/cheatsheet_syntax.md)
-
-# [5] Question for the Community
-
-We’ve made a thread for each section; please reply in the appropriate threads to help organize discussion!
-
-### We'll ship with some prebuilt workflows, what are some workflows to include? 
-If you can, try to use this format:
-
-#### Title of workflow (what does it do)
-
-Extract a field from a json
-
-#### Command
-
-`cat channel_versions.json | jq '.stable.versions'`
-
-#### Parameters
-
-`channel_versions.json` -> a json file
-
-#### Articulation or links to StackOverflow (or other sites)
-
-https://stackoverflow.com/questions/39228500/extract-a-specific-field-from-json-output-using-jq
+The existing preset files should serve as an example for the format, while the a more comprehensive description of the file format is available in [FORMAT.md](FORMAT.md). Please request a review from someone on the Warp team once a PR is ready for review.


### PR DESCRIPTION
1) Updates repos to include info on how to contribute
2) Adds a `Format` file that specifies exactly what the format of the file should look like. The format for this file was heavily inspired by https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobs