### PR TITLE
K8:add port-forward, scale, rollback, node state helpers

### DIFF
--- a/specs/kubernetes/mark_node_schedulable.yaml
+++ b/specs/kubernetes/mark_node_schedulable.yaml
@@ -1,0 +1,14 @@
+---
+name: Mark node as schedulable
+command: kubectl uncordon {{node}}
+tags:
+  - kubernetes
+description: "Mark node as schedulable"
+arguments:
+  - name: node
+    description: Node name
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#uncordon"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#uncordon"
+shells: []

--- a/specs/kubernetes/mark_node_unschedulable.yaml
+++ b/specs/kubernetes/mark_node_unschedulable.yaml
@@ -1,0 +1,14 @@
+---
+name: Mark node as unschedulable
+command: kubectl cordon {{node}}
+tags:
+  - kubernetes
+description: "Mark node as unschedulable"
+arguments:
+  - name: node
+    description: Node name
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cordon"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#cordon"
+shells: []

--- a/specs/kubernetes/pod_port_forward.yaml
+++ b/specs/kubernetes/pod_port_forward.yaml
@@ -1,0 +1,20 @@
+---
+name: Forward one or more local ports to a pod.
+command: kubectl port-forward pod/{{pod_name}} {{local_port}}:{{pod_port}}
+tags:
+  - kubernetes
+description: "Listen on port specified locally, forwarding to {{pod_port}} in the pod"
+arguments:
+  - name: pod_name
+    description: The specified pod name
+    default_value: ~
+  - name: local_port
+    description: localhost port number
+    default_value: ~
+  - name: pod_port
+    description: pod port number
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward"
+shells: []

--- a/specs/kubernetes/rollback_to_previous_deployment.yaml
+++ b/specs/kubernetes/rollback_to_previous_deployment.yaml
@@ -1,0 +1,14 @@
+---
+name: Rollback to the previous deployment
+command: kubectl rollout undo deployment/{{deployment_name}}
+tags:
+  - kubernetes
+description: "Rollback to the previous deployment"
+arguments:
+  - name: deployment_name
+    description: deployment name
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#rollout"
+shells: []

--- a/specs/kubernetes/scale_deployment.yaml
+++ b/specs/kubernetes/scale_deployment.yaml
@@ -1,0 +1,17 @@
+---
+name: Set a new size for a deployment.
+command: kubectl scale deployment/{{deployment_name}} --replicas={{count}}
+tags:
+  - kubernetes
+description: "Set a new size for a deployment. If --current-replicas or --resource-version is specified, it is validated before the scale is attempted, and it is guaranteed that the precondition holds true when the scale is sent to the server."
+arguments:
+  - name: deployment_name
+    description: The specified deployment name
+    default_value: ~
+  - name: count
+    description: desired replica count
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#scale"
+shells: []

--- a/specs/kubernetes/svc_port_forward.yaml
+++ b/specs/kubernetes/svc_port_forward.yaml
@@ -1,0 +1,20 @@
+---
+name: Forward one or more local ports of a service
+command: kubectl port-forward svc/{{service_name}} {{local_port}}:{{service_port}}
+tags:
+  - kubernetes
+description: "Listen on port specified locally, forwarding to the targetPort of the service's port with the same value in a pod selected by the service."
+arguments:
+  - name: service_name
+    description: The specified service name
+    default_value: ~
+  - name: local_port
+    description: localhost port number
+    default_value: ~
+  - name: service_port
+    description: service port number
+    default_value: ~
+source_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward"
+author: AI
+author_url: "https://kubernetes.io/docs/reference/generated/kubectl/kubectl-commands#port-forward"
+shells: []


### PR DESCRIPTION
This adds helpers for:

- port forward from service/pod;
- scale deployment;
- rollback to the previous deployment;
- node state (schedulable/unschedulable).