### PR TITLE
Support yaml and yml extensions in build script.

### DIFF
--- a/workflows/build.rs
+++ b/workflows/build.rs
@@ -41,6 +41,7 @@ fn main() -> Result<()> {
                 .to_str()
                 .expect("OsStr should convert to str")
                 .replace(".yaml", "")
+                .replace(".yml", "")
                 .to_case(Case::Snake);
             println!("file name is {:?}", file_name);
 


### PR DESCRIPTION
Prior to this, we only built the module name for the workflow correctly if the workflow file ended with a `.yaml` extension. Since we also support `.yml` extensions, we should remove the extension from the module name in this case too. 