### PR TITLE
workflow: add list and kill processes at port workflows

### DIFF
--- a/specs/shell/kill_processes_at_port.yaml
+++ b/specs/shell/kill_processes_at_port.yaml
@@ -3,9 +3,6 @@ description: Kill processes at a port.
 author: Maurice Gerhardt
 author_url: https://github.com/heymage
 tags: ["macos", "shell"]
-shells:
-  - zsh
-  - bash
 command: kill $(lsof -t -i:{{port}})
 arguments:
   - name: port

--- a/specs/shell/kill_processes_at_port.yaml
+++ b/specs/shell/kill_processes_at_port.yaml
@@ -1,0 +1,12 @@
+name: Kill processes at port
+description: Kill processes at a port.
+author: Maurice Gerhardt
+author_url: https://github.com/heymage
+tags: ["macos", "shell"]
+shells:
+  - zsh
+  - bash
+command: kill $(lsof -t -i:{{port}})
+arguments:
+  - name: port
+    description: The port where processes should be killed

--- a/specs/shell/list_processes_at_port.yaml
+++ b/specs/shell/list_processes_at_port.yaml
@@ -1,0 +1,12 @@
+name: List processes at port
+description: List processes at a port to see if there are running processes.
+author: Maurice Gerhardt
+author_url: https://github.com/heymage
+tags: ["macos", "shell"]
+shells:
+  - zsh
+  - bash
+command: lsof -i:{{port}}
+arguments:
+  - name: port
+    description: The port that should be checked

--- a/specs/shell/list_processes_at_port.yaml
+++ b/specs/shell/list_processes_at_port.yaml
@@ -3,9 +3,6 @@ description: List processes at a port to see if there are running processes.
 author: Maurice Gerhardt
 author_url: https://github.com/heymage
 tags: ["macos", "shell"]
-shells:
-  - zsh
-  - bash
 command: lsof -i:{{port}}
 arguments:
   - name: port


### PR DESCRIPTION
Hey,
I added two workflows related to processes running at specific ports.
Especially handy if you work with parallel processes while testing or similar.