### PR TITLE
Remove extra nativescript tags

### DIFF
--- a/specs/nativescript/add_platform.yaml
+++ b/specs/nativescript/add_platform.yaml
@@ -1,8 +1,6 @@
 name: Configure your current NativeScript project to target the selected platform.
 command: "ns platform add {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Configures the current NativeScript project to target the selected platform. When you add a target platform, the NativeScript CLI creates a corresponding platform-specific subdirectory under the platforms directory. This platform-specific directory contains the necessary files to let you build your project for the target platform."
 arguments:

--- a/specs/nativescript/build_the_project.yaml
+++ b/specs/nativescript/build_the_project.yaml
@@ -1,8 +1,6 @@
 name: Build your NativeScript project for Android or iOS.
 command: "ns build {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Builds your NativeScript project for Android or iOS and produces an application package that you can manually deploy on a device or native emulator."
 arguments:

--- a/specs/nativescript/check_nativescript_system_configuration.yaml
+++ b/specs/nativescript/check_nativescript_system_configuration.yaml
@@ -1,8 +1,6 @@
 name: Check Nativescript system's configuration.
 command: "ns doctor {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Checks your system for configuration problems which might prevent the NativeScript CLI from working properly for the specified platform, if configured."
 arguments:

--- a/specs/nativescript/clean_project_artifacts.yaml
+++ b/specs/nativescript/clean_project_artifacts.yaml
@@ -1,8 +1,6 @@
 name: Clean your NativeScript project artifacts.
 command: "ns clean"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Cleans your NativeScript project artifacts."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/clean.md"

--- a/specs/nativescript/configure_error_reporting.yaml
+++ b/specs/nativescript/configure_error_reporting.yaml
@@ -1,8 +1,6 @@
 name: Configure NativeScript CLI error reporting.
 command: "ns error-reporting"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Configures anonymous error reporting for the NativeScript CLI."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/error-reporting.md"

--- a/specs/nativescript/configure_shell_autocompletion.yaml
+++ b/specs/nativescript/configure_shell_autocompletion.yaml
@@ -1,8 +1,6 @@
 name: Configure NativeScript command-line autocompletion.
 command: "ns autocomplete {{command}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Prints your current NativeScript command-line completion settings. If disabled, prompts you to enable it."
 arguments:

--- a/specs/nativescript/configure_unit_testing_framework.yaml
+++ b/specs/nativescript/configure_unit_testing_framework.yaml
@@ -1,8 +1,6 @@
 name: Configures your NativeScript project for unit testing with a selected framework.
 command: "ns test init {{framework}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Configures your NativeScript project for unit testing with a selected framework. This operation installs the @nativescript/unit-test-runner npm module and its dependencies and creates a tests folder in the app directory."
 arguments:

--- a/specs/nativescript/configure_usage_reporting.yaml
+++ b/specs/nativescript/configure_usage_reporting.yaml
@@ -1,8 +1,6 @@
 name: Configure NativeScript CLI usage reporting.
 command: "ns usage-reporting"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Configures anonymous usage reporting for the NativeScript CLI."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/usage-reporting.md"

--- a/specs/nativescript/create_nativecript_app.yaml
+++ b/specs/nativescript/create_nativecript_app.yaml
@@ -1,8 +1,6 @@
 name: Create a NativeScript app.
 command: "ns create {{app_name}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Interactively creates a new NativeScript app based on a predefined template."
 arguments:

--- a/specs/nativescript/debug_the_project.yaml
+++ b/specs/nativescript/debug_the_project.yaml
@@ -1,8 +1,6 @@
 name: Initiate a debugging session for your NativeScript project.
 command: "ns debug {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Initiates a debugging session for your NativeScript project on a connected device or native emulator. The command will prepare, build, deploy and launch the app before starting the debug session."
 arguments:

--- a/specs/nativescript/deploy_the_project.yaml
+++ b/specs/nativescript/deploy_the_project.yaml
@@ -1,8 +1,6 @@
 name: Prepare, build and deploy your NativeScript project to a connected device or native emulator.
 command: "ns deploy {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Prepares, builds and deploys your NativeScript project to a connected device or native emulator. It will deploy the app on all connected devices targeting the selected platform."
 arguments:

--- a/specs/nativescript/display_nativescript_proxy_settings.yaml
+++ b/specs/nativescript/display_nativescript_proxy_settings.yaml
@@ -1,8 +1,6 @@
 name: Display proxy settings of the NativeScript CLI.
 command: "ns proxy"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Displays the current proxy settings of the NativeScript CLI."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/proxy.md"

--- a/specs/nativescript/display_version_information_about_nativescript.yaml
+++ b/specs/nativescript/display_version_information_about_nativescript.yaml
@@ -1,8 +1,6 @@
 name: Display version information about NativeScript.
 command: "ns info"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Displays version information about the NativeScript CLI, core modules, and runtimes."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/info.md"

--- a/specs/nativescript/generate_icons_resource.yaml
+++ b/specs/nativescript/generate_icons_resource.yaml
@@ -1,8 +1,6 @@
 name: Generate all icons for Android and iOS platforms for your NativeScript project.
 command: "ns resources generate icons {{path_to_image}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Generates all icons for Android and iOS platforms for your NativeScript. It places the generated images in the correct directories under App_Resources/<platform> directory."
 arguments:

--- a/specs/nativescript/generate_platform_typings.yaml
+++ b/specs/nativescript/generate_platform_typings.yaml
@@ -1,8 +1,6 @@
 name: Generate platform's (iOS and/or Android) typings for your NativeScript project.
 command: "ns typings {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Generate iOS & Android typings for your NativeScript project. By default respecting platform support, so no iOS typings generated on Windows/Linux machines."
 arguments:

--- a/specs/nativescript/generate_splashscreens_resource.yaml
+++ b/specs/nativescript/generate_splashscreens_resource.yaml
@@ -1,8 +1,6 @@
 name: Generate all splashscreens for Android and iOS platforms for your NativeScript project.
 command: "ns resources generate splashes {{path_to_image}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Generates all splashscreens for Android and iOS platforms for your NativeScript project. It places the generated images in the correct directories under App_Resources/<platform> directory."
 arguments:

--- a/specs/nativescript/install_dependencies.yaml
+++ b/specs/nativescript/install_dependencies.yaml
@@ -1,8 +1,6 @@
 name: Install dependencies for your NativeScript project.
 command: "ns install {{module}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Installs all dependencies described in a valid package.json or installs a selected NativeScript development module as a dev dependency."
 arguments:

--- a/specs/nativescript/list_applications_installed_on_a_device.yaml
+++ b/specs/nativescript/list_applications_installed_on_a_device.yaml
@@ -1,8 +1,6 @@
 name: List applications installed on a device using NativeScript CLI.
 command: "ns device list-applications"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "NativeScript lists the installed applications on all connected Android and iOS devices."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/device/device-list-applications.md"

--- a/specs/nativescript/list_applications_records_in_itunes_connect.yaml
+++ b/specs/nativescript/list_applications_records_in_itunes_connect.yaml
@@ -1,8 +1,6 @@
 name: List all application records in iTunes Connect using NativeScript CLI.
 command: "ns appstore {{apple_id}} {{password}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "NativeScript lists all application records in iTunes Connect. The list contains name, version and bundle ID for each application record."
 arguments:

--- a/specs/nativescript/list_connected_devices.yaml
+++ b/specs/nativescript/list_connected_devices.yaml
@@ -1,8 +1,6 @@
 name: List all recognized connected devices using NativeScript CLI.
 command: "ns device {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "NativeScript lists all recognized connected Android or iOS devices with serial number and index, grouped by platform."
 arguments:

--- a/specs/nativescript/list_platforms.yaml
+++ b/specs/nativescript/list_platforms.yaml
@@ -1,8 +1,6 @@
 name: Lists all platforms that your NativeScript project currently targets.
 command: "ns platform list"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Lists all platforms that your NativeScript project currently targets. You can build and deploy your project only for these target platforms."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/project/configuration/platform.md"

--- a/specs/nativescript/manage_plugins.yaml
+++ b/specs/nativescript/manage_plugins.yaml
@@ -1,8 +1,6 @@
 name: Manage Plugins in your NativeScript project.
 command: "ns plugin {{command}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Lets you manage the plugins for your NativeScript project."
 arguments:

--- a/specs/nativescript/migrate_nativescript_dependencies_to_the_latest_version copy.yaml
+++ b/specs/nativescript/migrate_nativescript_dependencies_to_the_latest_version copy.yaml
@@ -1,8 +1,6 @@
 name: Migrate Nativescript dependencies to the latest version.
 command: "ns migrate"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Migrates the app dependencies to a form compatible with the latest NativeScript. Running this command will not affect the codebase of the application and you might need to do additional changes manually."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/migrate.md"

--- a/specs/nativescript/open_device_log_stream.yaml
+++ b/specs/nativescript/open_device_log_stream.yaml
@@ -1,8 +1,6 @@
 name: Open the device log stream using NativeScript CLI.
 command: "ns device log"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "NativeScript opens the device log stream for a selected connected Android or iOS device."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/device/device-log.md"

--- a/specs/nativescript/prepare_resources_and_platforms.yaml
+++ b/specs/nativescript/prepare_resources_and_platforms.yaml
@@ -1,8 +1,6 @@
 name: Prepare the app's App_Resources and the plugins platforms directories in your NativeScript project.
 command: "ns prepare {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Starts a Webpack compilation and prepares the app's App_Resources and the plugins platforms directories in your NativeScript project. The output is generated in a subdirectory for the selected target platform in the platforms directory. This lets you build the project for the selected platform."
 arguments:

--- a/specs/nativescript/remove_platform.yaml
+++ b/specs/nativescript/remove_platform.yaml
@@ -1,8 +1,6 @@
 name: Remove the selected platform from your NativeScript project.
 command: "ns platform remove {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Removes the selected platform from the platforms that your NativeScript project currently targets. After removing the target platform, you can no longer build and deploy your app on devices which run on the platform."
 arguments:

--- a/specs/nativescript/run_project_on_device.yaml
+++ b/specs/nativescript/run_project_on_device.yaml
@@ -1,8 +1,6 @@
 name: Run the selected NativeScript application on a connected device.
 command: "ns run {{application_id}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Runs the selected NativeScript application on a connected Android or iOS device."
 arguments:

--- a/specs/nativescript/run_the_project.yaml
+++ b/specs/nativescript/run_the_project.yaml
@@ -1,8 +1,6 @@
 name: Run the NativeScript project for Android or iOS.
 command: "ns run {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Runs your NativeScript project on all connected devices or in native emulators for the selected platform. The command will work with all currently running Android devices and emulators. The command will prepare, build and deploy the app when necessary. By default listens for changes in your code, synchronizes those changes and refreshes all selected devices."
 arguments:

--- a/specs/nativescript/run_unit_tests.yaml
+++ b/specs/nativescript/run_unit_tests.yaml
@@ -1,8 +1,6 @@
 name: Run unit tests on your NativeScript project.
 command: "ns test {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Runs unit tests on the selected mobile platform. Your NativeScript project must already be configured for unit testing by running $ ns test init."
 arguments:

--- a/specs/nativescript/show_current_package_manager.yaml
+++ b/specs/nativescript/show_current_package_manager.yaml
@@ -1,8 +1,6 @@
 name: Show current package manager using NativeScript CLI.
 command: "ns package-manager"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "NativeScript prints the value of the current package manager."
 source_url: "https://github.com/NativeScript/nativescript-cli/blob/master/docs/man_pages/general/package-manager.md"

--- a/specs/nativescript/show_help_about_the_commands_in_the_browser.yaml
+++ b/specs/nativescript/show_help_about_the_commands_in_the_browser.yaml
@@ -1,8 +1,6 @@
 name: Show information about the NativeScript CLI commands in the browser.
 command: "ns help {{command}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Shows additional information about the NativeScript CLI commands in this list in the browser."
 arguments:

--- a/specs/nativescript/update_nativescript_dependencies_to_the_latest_version.yaml
+++ b/specs/nativescript/update_nativescript_dependencies_to_the_latest_version.yaml
@@ -1,8 +1,6 @@
 name: Update Nativescript dependencies to the latest version.
 command: "ns update {{version}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Updates your NativeScript project with the latest versions of iOS/Android runtimes, cross-platform modules and @nativescript/webpack."
 arguments:

--- a/specs/nativescript/update_platform.yaml
+++ b/specs/nativescript/update_platform.yaml
@@ -1,8 +1,6 @@
 name: Update the NativeScript runtime for the specified platform.
 command: "ns platform update {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Updates the NativeScript runtime for the specified platform."
 arguments:

--- a/specs/nativescript/update_resource.yaml
+++ b/specs/nativescript/update_resource.yaml
@@ -1,8 +1,6 @@
 name: Update the App_Resources's folder structure in your NativeScript project.
 command: "ns resources update {{platform}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Updates the App_Resources/'s internal folder structure in your NativeScript project to conform to that of an Android Studio project."
 arguments:

--- a/specs/nativescript/upload_project_to_itunes_connect .yaml
+++ b/specs/nativescript/upload_project_to_itunes_connect .yaml
@@ -1,8 +1,6 @@
 name: Upload NativeScript project to iTunes Connect.
 command: "ns appstore upload {{apple_id}} {{password}} {{mobile_provisioning_profile_identifier}} {{code_sign_identity}}"
 tags:
-  - ns
-  - tns
   - nativescript
 description: "Uploads your NativeScript project to iTunes Connect. The command either issues a production build and uploads it to iTunes Connect, or uses an already built package to upload."
 arguments:


### PR DESCRIPTION
The nativescript workflows had many duplicate tags, which leads to a less-than-ideal experience within Warp since it increases the number of categories within the sidebar. 

As a cleanup, I consolidated all of them to only include the `nativescript` tag 