### PR TITLE
Include '' to sed command since it's necessary on OSX

### DIFF
--- a/specs/file_manipulation/recursively_find_and_replace_within_a_directory.yaml
+++ b/specs/file_manipulation/recursively_find_and_replace_within_a_directory.yaml
@@ -1,6 +1,6 @@
 ---
 name: Recursively find and replace within a directory
-command: "grep -rl {{old_text}} {{file_path}} | xargs sed -i 's/{{old_text}}/{{new_text}}/g'"
+command: "grep -rl {{old_text}} {{file_path}} | xargs sed -i '' 's/{{old_text}}/{{new_text}}/g'"
 tags:
   - file manipulation
   - sed


### PR DESCRIPTION
On the OSX version of sed, the -i option expects an extension argument to back up the files. It's already in all the other sed specs, do the same here.

By providing '', we're making it modify files in-place which is what the user expects from the workflow.