### PR TITLE
consider using environment vars for terminal

### DIFF
--- a/specs/docker/start_a_bash_shell_within_a_docker_container.yaml
+++ b/specs/docker/start_a_bash_shell_within_a_docker_container.yaml
@@ -1,6 +1,6 @@
 ---
 name: Start a Bash shell within a Docker container
-command: "docker exec -it {{container_name}} bash"
+command: "sudo docker exec -it -e COLUMNS=\"`tput cols`\" -e LINES=\"`tput lines`\" {{container_name}} /bin/bash"
 tags:
   - docker
 description: Runs a Bash subshell within a Docker container.


### PR DESCRIPTION
Adding environment variables for columns and lines can fix terminal issues when entering a container.
also 
```-e COLUMNS=$COLUMNS -e LINES=$LINES -e TERM=$TERM``` if no command subprocess is desired

## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)

## Description of changes (updated or new workflows)
