### PR TITLE
feat: introduce `remote` variable in "Reset local branch to match remote branch"

### DIFF
--- a/specs/git/reset_local_branch_to_match_remote_branch.yaml
+++ b/specs/git/reset_local_branch_to_match_remote_branch.yaml
@@ -1,13 +1,16 @@
 ---
 name: Reset local branch to match remote branch
-command: "git fetch origin\ngit reset --hard {{branch}}"
+command: "git fetch {{remote}}\ngit reset --hard {{remote}}/{{branch}}"
 tags:
   - git
 description: Resets a local branch to match a remote branch by pulling the most recent changes from the remote branch and then force resetting the local branch to match the remote branch.
 arguments:
+  - name: remote
+    description: The name of the remote
+    default_value: origin
   - name: branch
     description: The name of the remote branch that the local branch should be reset to
-    default_value: origin/master
+    default_value: master
 source_url: "https://stackoverflow.com/questions/1628088/reset-local-repository-branch-to-be-just-like-remote-repository-head"
 author: Dan Moulding
 author_url: "https://stackoverflow.com/users/95706/dan-moulding"


### PR DESCRIPTION
## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)
pfialho#7144

## Description of changes (updated or new workflows)
This adds a `remote` variable and isolates the branch name in the `branch` variable. Should the remote name be different than `origin`, this generates the correct `fetch` command.
It also makes it easier and less error-prone to customize the branch name, by guaranteeing that there's always a remote in the `reset` command and making it impossible to not include the slash (`/`) character in final snippet.