### PR TITLE
fix workflow - find files not containing a string

### DIFF
--- a/specs/file_manipulation/find_all_files_in_a_directory_that_dont_contain_a_string.yaml
+++ b/specs/file_manipulation/find_all_files_in_a_directory_that_dont_contain_a_string.yaml
@@ -1,13 +1,16 @@
 ---
 name: "Find all files in a directory that don't contain a string"
-command: "grep -L \"foo\" {{pattern}}"
+command: 'grep -L "{{string}}" {{directory}}'
 tags:
   - search
   - grep
-description: "Finds all files in a repository that don't contain a given pattern."
+description: "Finds all files in a directory that don't contain a given string."
 arguments:
-  - name: pattern
-    description: The pattern to search for
+  - name: string
+    description: The string to search for
+    default_value: ~
+  - name: directory
+    description: The directory to search. Use '*' for current directory.
     default_value: ~
 source_url: "https://stackoverflow.com/questions/1748129/how-do-i-find-files-that-do-not-contain-a-given-string-pattern"
 author: ghostdog74


### PR DESCRIPTION
## Discord username: Andrei 𓄁#5107

## Description of changes (updated or new workflows)
The original workflow was a bit misleading and caused an error if it was run as-is. It used `string` and `pattern` interchangeably. Here are the issues:
* the `pattern` argument is placed where the `pathname/directory` argument should be. This leads to an error because `grep` tries to look in the `pattern` directory or file and can't find it.
  
  <img width="981" alt="Screen Shot 2022-06-22 at 20 53 49" src="https://user-images.githubusercontent.com/24983797/175023826-8f694931-449c-4486-ad0c-c48ca27d772c.png">

  <img width="348" alt="Screen Shot 2022-06-22 at 20 55 23" src="https://user-images.githubusercontent.com/24983797/175023476-4a7ebba1-614b-40bb-b4fb-5fe85e175fb1.png">

* it hardcoded the string `"foo"` instead of making it an argument.

Here are my changes in a local version of Warp.
<img width="981" alt="Screen Shot 2022-06-22 at 20 53 34" src="https://user-images.githubusercontent.com/24983797/175024252-279a0333-fdd3-4e05-9c2f-f02b6756a65d.png">

## Questions
1. Is the mix of single and double quotes OK? It seems to be OK according to the YAML docs [linked](https://learnxinyminutes.com/docs/yaml/#:~:text=%23%20Notice%20that%20strings,n%2C%20and%20more.%22) by `FORMAT.md`. I can use escaped double quotes if needed.
2. Is the wording OK? My goal was to be consistent and not use 2 terms interchangeably.
3. Is it better if the `directory` argument has a default of `*` for the current directory? 
