### PR TITLE
Replace foo with {{pattern}}

### DIFF
--- a/specs/file_manipulation/find_all_files_in_a_directory_that_dont_contain_a_string.yaml
+++ b/specs/file_manipulation/find_all_files_in_a_directory_that_dont_contain_a_string.yaml
@@ -1,6 +1,6 @@
 ---
 name: "Find all files in a directory that don't contain a string"
-command: "grep -L \"foo\" {{pattern}}"
+command: "grep -L \"{{pattern}}\" "
 tags:
   - search
   - grep


### PR DESCRIPTION
Allows proper copy example function. 

## Description of changes

Updated find_all_files_in_a_directory_that_dont_contain_a_string

