### PR TITLE
Add workflow for pushing a firebase push notification onto your emulator

### DIFF
--- a/specs/android/adb_root_emulator.yaml
+++ b/specs/android/adb_root_emulator.yaml
@@ -1,0 +1,10 @@
+---
+name: Root your emulator
+command: adb root
+tags:
+  - android
+  - adb
+description: Roots your Android emulator
+author: Odin Asbjørnsen
+author_url: https://github.com/oas004
+shells: []

--- a/specs/android/send_firebase_push_notification.yaml
+++ b/specs/android/send_firebase_push_notification.yaml
@@ -1,0 +1,29 @@
+---
+name: Send a firebase push notification to local Android emulator
+command: adb shell am broadcast \
+  -n {{your_app_package_name}}/com.google.firebase.iid.FirebaseInstanceIdReceiver \
+  -a "com.google.android.c2dm.intent.RECEIVE" \
+           --es "title" "{{notification_title}}" \
+           --es "body" "{{notification_body}}" \
+           --es "deeplink" "{{deeplink}}"
+tags:
+  - android
+  - adb
+  - firbase
+  - notification
+description: Uses adb to push a Firebase push notification to your local emulator. Remember that your emulator has to be rooted.You can run `adb root` or the root emulator workflow. Furthermore, you need to implement the firebase provider. This is recomended todo in your debug manifest.
+arguments:
+  - name: your_app_package_name
+    description: The package name of the app that you want to recieve the notification. It has to have implemented the reciever for it to work.
+    default_value: com.my.app.package
+  - name: notification_title
+    description: The title of the notification
+    default_value: title
+  - name: notification_body
+    description: The body of the notification
+    default_value: body
+  - name: deep_link
+    description: A deeplink for the notification (eg. `app://open.my.app`)
+author: Odin Asbjørnsen
+author_url: https://github.com/oas004
+shells: []

--- a/specs/android/send_firebase_push_notification.yaml
+++ b/specs/android/send_firebase_push_notification.yaml
@@ -1,5 +1,5 @@
 ---
-name: Send a firebase push notification to local Android emulator
+name: Send a Firebase push notification to a local Android emulator
 command: adb shell am broadcast \
   -n {{your_app_package_name}}/com.google.firebase.iid.FirebaseInstanceIdReceiver \
   -a "com.google.android.c2dm.intent.RECEIVE" \
@@ -9,9 +9,8 @@ command: adb shell am broadcast \
 tags:
   - android
   - adb
-  - firbase
-  - notification
-description: Uses adb to push a Firebase push notification to your local emulator. Remember that your emulator has to be rooted.You can run `adb root` or the root emulator workflow. Furthermore, you need to implement the firebase provider. This is recomended todo in your debug manifest.
+  - firebase
+description: Uses adb to push a Firebase push notification to your local emulator
 arguments:
   - name: your_app_package_name
     description: The package name of the app that you want to recieve the notification. It has to have implemented the reciever for it to work.


### PR DESCRIPTION
Thanks so much for this repo and the Warp terminal! 😄 I use it every day now! 🙌  I used this workflow a lot for mocking firebase notifications onto the emulator, so I thought it might be cool to have in this repo as well. If you don't agree, please feel free to close it 😄 

## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)
Discord username: Odin#6313

## Description of changes (updated or new workflows)
Added a workflow for pushing a firebase notification onto an Android emulator. This requires that the device is rooted, so I added a workflow for that as well. Bit unsure if that is the best or if it should be combined. 

The workflow also requires you to have implemented the firebase provider or service, so I added a comment about that in the description. 
