### PR TITLE
Jamf & Chef workflows

### DIFF
--- a/specs/chef/run_cookbook_manually.yml
+++ b/specs/chef/run_cookbook_manually.yml
@@ -2,10 +2,8 @@
 name: Manually run a cookbook by name
 command: sudo chef client -o recipe['{{cookbook}}'] 
 tags:
-  - macos
-  - linux
   - chef
-description: Use to fun a cookbook manually
+description: Use to run a cookbook manually
 arguments:
   - name: cookbook
     description: Name of the cookbook

--- a/specs/chef/run_cookbook_manually.yml
+++ b/specs/chef/run_cookbook_manually.yml
@@ -1,0 +1,15 @@
+---
+name: Manually run a cookbook by name
+command: sudo chef client -o recipe['{{cookbook}}'] 
+tags:
+  - macos
+  - linux
+  - chef
+description: Use to fun a cookbook manually
+arguments:
+  - name: cookbook
+    description: Name of the cookbook
+source_url: https://docs.chef.io/ctl_chef_client
+author: Amado Tejada
+author_url: https://github.com/amadotejada
+shells: []

--- a/specs/jamf/manually_initiate_policy_custom_id.yml
+++ b/specs/jamf/manually_initiate_policy_custom_id.yml
@@ -1,0 +1,14 @@
+---
+name: Manually Initiate a Policy via policy ID
+command: sudo jamf policy -event "{{policy_id}}" -verbose
+tags:
+  - macos
+  - jamf
+  - mdm
+description: Use to run a Jamf policy manually
+arguments:
+  - name: policy_id
+    description: The ID number of the Jamf policy
+author: Amado Tejada
+author_url: https://github.com/amadotejada
+shells: []

--- a/specs/jamf/manually_initiate_policy_custom_id.yml
+++ b/specs/jamf/manually_initiate_policy_custom_id.yml
@@ -1,14 +1,12 @@
 ---
-name: Manually Initiate a Policy via policy ID
+name: Manually initiate a policy via policy id
 command: sudo jamf policy -event "{{policy_id}}" -verbose
 tags:
-  - macos
   - jamf
-  - mdm
 description: Use to run a Jamf policy manually
 arguments:
   - name: policy_id
-    description: The ID number of the Jamf policy
+    description: The id number of the Jamf policy
 author: Amado Tejada
 author_url: https://github.com/amadotejada
 shells: []

--- a/specs/jamf/manually_initiate_policy_custom_triggername.yml
+++ b/specs/jamf/manually_initiate_policy_custom_triggername.yml
@@ -1,0 +1,15 @@
+---
+name: Manually Initiate a Policy via policy triggerName
+command: sudo jamf policy -event "{{triggerName}}" -verbose
+tags:
+  - macos
+  - jamf
+  - mdm
+description: Use to run a Jamf policy manually
+arguments:
+  - name: triggerName
+    description: Custom triggerName of the Jamf policy
+source_url: https://docs.jamf.com/technical-articles/Manually_Initiating_a_Policy.html
+author: Amado Tejada
+author_url: https://github.com/amadotejada
+shells: []

--- a/specs/jamf/manually_initiate_policy_custom_triggername.yml
+++ b/specs/jamf/manually_initiate_policy_custom_triggername.yml
@@ -1,14 +1,12 @@
 ---
-name: Manually Initiate a Policy via policy triggerName
+name: Manually initiate a policy via policy trigger name
 command: sudo jamf policy -event "{{triggerName}}" -verbose
 tags:
-  - macos
   - jamf
-  - mdm
 description: Use to run a Jamf policy manually
 arguments:
   - name: triggerName
-    description: Custom triggerName of the Jamf policy
+    description: Custom trigger name of the Jamf policy
 source_url: https://docs.jamf.com/technical-articles/Manually_Initiating_a_Policy.html
 author: Amado Tejada
 author_url: https://github.com/amadotejada

--- a/specs/jamf/manually_initiate_recon.yml
+++ b/specs/jamf/manually_initiate_recon.yml
@@ -1,0 +1,11 @@
+---
+name: Manually Initiate a recon inventory
+command: sudo jamf recon
+tags:
+  - macos
+  - jamf
+  - mdm
+description: Force a full Jamf inventory from the client
+author: Amado Tejada
+author_url: https://github.com/amadotejada
+shells: []

--- a/specs/jamf/manually_initiate_recon.yml
+++ b/specs/jamf/manually_initiate_recon.yml
@@ -1,10 +1,8 @@
 ---
-name: Manually Initiate a recon inventory
+name: Manually initiate a recon inventory
 command: sudo jamf recon
 tags:
-  - macos
   - jamf
-  - mdm
 description: Force a full Jamf inventory from the client
 author: Amado Tejada
 author_url: https://github.com/amadotejada


### PR DESCRIPTION
## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)

Discord: Amado#4572

## Description of changes (updated or new workflows)
New JAMF and Chef workflows for Client Platform Engineers
Commonly, used during testing new policy/cookbook deployments

- run a Jamf policy manually by trigger name
- run a Jamf policy manually by ID
- run a Jamf recon for push inventory info
- run a Chef cookbook manually 
