### PR TITLE
add clone_all_repos_in_org workflow

### DIFF
--- a/specs/git/clone_all_repos_in_org.yaml
+++ b/specs/git/clone_all_repos_in_org.yaml
@@ -1,0 +1,35 @@
+---
+# The name of the workflow.
+name: Clone all repos in a GitHub Organization
+# The corresponding command for the workflow. Any arguments should be surrounded with two curly braces. E.g `command {{arg}}`.
+command: |-
+    curl -s -H "Authorization: token {{auth_token}}" "https://api.github.com/orgs/{{org}}/repos?page={{page}}&per_page=100" | jq -r ".[].clone_url" | xargs -L1 git clone  
+# Any tags that the workflow should be categorized with.
+tags:
+  - git
+  - github
+# A description of the workflow.
+description: Uses the GitHub API to retrieve a list of repos (up to 100 per page) and clones them.
+# List of arguments within the command.
+arguments:
+    # Name of the argument within the command. This must exactly match the name of the argument
+    # within the command (without the curly braces).
+  - name: auth_token
+    # The description of the argument.
+    description: A personal Authorization Token created on GitHub (may need to enable SAML after token is created) https://github.com/settings/tokens
+  - name: org
+    description: The organization name (ex. facebook)
+    # The default value for the argument.
+    default_value: facebook 
+  - name: page
+    description: Page number
+    default_value: 1
+# The source URL for where the workflow was generated from, if any.
+source_url: "https://medium.com/rigor-guild/clone-all-github-repositories-in-an-organization-36ab87b94d7c"
+# The author of the workflow.
+author: Carlos Buenosvinos
+# The URL of original author of the Workflow. For example, if this workflow was generated from StackOverflow, the `author_url` would be the StackOverflow author's profile page.
+author_url: "https://medium.com/@carlosbuenosvinos"
+# The valid shells where this workflow should be active. If valid for all shells, this can be left empty.
+# See FORMAT.md for the full list of accepted values.
+shells: []


### PR DESCRIPTION
## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)

## Description of changes (updated or new workflows)

Added a workflow to clone all repos in a given organization from GitHub. This may be better suited in a new `github` directory rather than the `git` directory but I put it here.

It also occurs to me that this requires `jq` so it may not be at all appropriate for your project, but I'll let you decide and close this PR.