### PR TITLE
Add `clone-with-ssh.yaml` workflow

### DIFF
--- a/specs/git/clone-with-ssh.yaml
+++ b/specs/git/clone-with-ssh.yaml
@@ -1,0 +1,32 @@
+---
+name: Clone git repository with specific SSH Key and User
+command: |-
+  git -c core.sshCommand='ssh -i {{sshKeyPath}} -o IdentitiesOnly=yes' clone {{repositoryUrl}} {{targetFolder}}
+  cd {{targetFolder}}
+  git config core.sshCommand 'ssh -i {{sshKeyPath}}'
+  git config user.name "{{userName}}"
+  git config user.email {{userEmail}}
+tags:
+  - git
+  - ssh
+description: Clones a git repository given a specific SSH Key Path and configures it to use the desired Name and Email
+arguments:
+  - name: sshKeyPath
+    description: The path of the SSH Key to be used
+    default_value: ~/.ssh/id_rsa
+  - name: repositoryUrl
+    description: The SSH URL of the git repository
+    default_value: <repo_url>
+  - name: targetFolder
+    description: The name of the folder in which the repository should be cloned into
+    default_value: <target_folder>
+  - name: userName
+    description: The Name of the User to be configured for the git repository
+    default_value: Jhon Doe
+  - name: userEmail
+    description: The Email of the User to be configured for the git repository
+    default_value: johndoe@example.com
+source_url: "https://github.com/charlieVader/warp-workflows/blob/master/git/clone-with-ssh.yaml"
+author: charlieVader
+author_url: "https://github.com/charlieVader"
+shells: []


### PR DESCRIPTION
## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)
charlieVader#0702

## Description of changes (updated or new workflows)

When working on/with different clients and/or projects, there is this usual scenario in which we need to clone a git repository using an specific SSH Key, update its git configuration to set the correct User Name and Email and also to make sure it will be using the same SSH Key for further fetches, pulls, pushes, etc.

With this in mind (as I have spent lots of minutes/hours manually configuring each repository after cloning it), I finally got a Workflow working that makes all of that for me:

<img width="1013" alt="Screen Shot 2022-08-30 at 01 51 56" src="https://user-images.githubusercontent.com/4744884/187371992-aad8fd4e-bde0-47fe-a6d1-98f25b9088c0.png">

I can now run a single workflow, enter some values and off we go!

Thank you very much in advance for all the amazing work you guys have done.