### PR TITLE
Fix description on Laravel Nova workflow

### DIFF
--- a/specs/laravel/laravel_install_nova.yml
+++ b/specs/laravel/laravel_install_nova.yml
@@ -1,11 +1,11 @@
 ---
-name: Install Laravel Sail using Composer
+name: Install Laravel Nova using Composer
 command: 'composer config repositories.nova ''{"type": "composer", "url": "https://nova.laravel.com"}'' --file composer.json && composer require laravel/nova && composer update --prefer-dist'
 tags:
   - composer
   - laravel
   - php
-description: Install Laravel Sail using Composer
+description: Install Laravel Nova using Composer
 arguments: []
 source_url: "https://nova.laravel.com/docs/4.0/installation.html"
 author: Rob Mellett


### PR DESCRIPTION
The workflow that installs Laravel Nova currently has the wrong description. It's shown twice now.
<img width="722" alt="image" src="https://user-images.githubusercontent.com/5859352/203002738-735d4ade-f8bf-467d-896f-bc4a019a6775.png">
