### PR TITLE
Added laravel's official installer workflow

### DIFF
--- a/specs/laravel/laravel_installer.yml
+++ b/specs/laravel/laravel_installer.yml
@@ -1,0 +1,14 @@
+---
+name: Installing Laravel Installer
+command: |-
+     composer global require laravel/installer
+tags:
+     - composer
+     - laravel
+     - php
+description: Install Laravel Installer
+arguments: []
+source_url: "https://laravel.com/docs/5.4/installation"
+author: Charles Adu Boakye
+author_url: "https://www.linkedin.com/in/charles-adu-boakye/"
+shells: []


### PR DESCRIPTION
## Description of changes (updated or new workflows)

Added a workflow for installing Laravel's official installer via Composer, which is the main dependency manager for PHP.

<img width="729" alt="Screenshot 2022-12-27 at 06 34 37" src="https://user-images.githubusercontent.com/119391570/209719412-4f2cbc9c-45e9-4587-91d4-386c7a0bf4f9.png">
