### PR TITLE
Enable authenticating sudo commands via Touch ID

### DIFF
--- a/specs/shell/sudo_with_fingerprint.yaml
+++ b/specs/shell/sudo_with_fingerprint.yaml
@@ -1,0 +1,5 @@
+name: Sudo with FIngerprint
+command: cat <(head -n 1  /etc/pam.d/sudo) <(echo "auth       sufficient     pam_tid.so") <(tail -n +2 /etc/pam.d/sudo) > output && sudo mv output /etc/pam.d/sudo
+description: Enables TouchID authetification for sudo commands
+tags: ["macos"]
+author_url: https://www.imore.com/how-use-sudo-your-mac-touch-id


### PR DESCRIPTION
This workflow edits the /etc/pam.d/sudo file so that one can authenticate sudo commands with Touch ID. It is based on this guide: https://www.imore.com/how-use-sudo-your-mac-touch-id

## Discord username (optional) please include so we can attribute you with our Contributor role (like so elvis#4747)

## Description of changes (updated or new workflows)
