### PR TITLE
Add description field to Workflow constructor

### DIFF
--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -59,12 +59,16 @@ impl Workflow {
         &self.shells
     }
 
-    pub fn new(name: impl Into<String>, command: impl Into<String>) -> Self {
+    pub fn new(
+        name: impl Into<String>,
+        command: impl Into<String>,
+        description: Option<String>,
+    ) -> Self {
         Workflow {
             name: name.into(),
             command: command.into(),
             tags: vec![],
-            description: None,
+            description,
             arguments: vec![],
             source_url: None,
             author: None,

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -79,7 +79,7 @@ impl Workflow {
     }
 
     pub fn with_description(mut self, description: String) -> Self {
-        self.description = Some(description.clone());
+        self.description = Some(description);
         self
     }
 }

--- a/workflow-types/src/lib.rs
+++ b/workflow-types/src/lib.rs
@@ -59,16 +59,12 @@ impl Workflow {
         &self.shells
     }
 
-    pub fn new(
-        name: impl Into<String>,
-        command: impl Into<String>,
-        description: Option<String>,
-    ) -> Self {
+    pub fn new(name: impl Into<String>, command: impl Into<String>) -> Self {
         Workflow {
             name: name.into(),
             command: command.into(),
             tags: vec![],
-            description,
+            description: None,
             arguments: vec![],
             source_url: None,
             author: None,
@@ -79,6 +75,11 @@ impl Workflow {
 
     pub fn with_arguments(mut self, arguments: Vec<Argument>) -> Self {
         self.arguments = arguments;
+        self
+    }
+
+    pub fn with_description(mut self, description: String) -> Self {
+        self.description = Some(description.clone());
         self
     }
 }


### PR DESCRIPTION
## Description of changes (updated or new workflows)

Adds a description field to the Workflow constructor. Previously it was hardcoded to `None`, this allows it to be set when calling `Workflow::new()`.