### PR TITLE
Fix workflow description typos

### DIFF
--- a/specs/git/delete_local_git_branch.yaml
+++ b/specs/git/delete_local_git_branch.yaml
@@ -3,7 +3,7 @@ name: Delete local git branch
 command: "git branch --delete {{branch_name}}"
 tags:
   - git
-description: "Deletes a local git branch only if it has been fully merged into the upstream branch. To force delete the branch irrespective of the its merged status, add the `--force` flag."
+description: "Deletes a local git branch only if it has been fully merged into the upstream branch. To force delete the branch irrespective of its merged status, add the `--force` flag."
 arguments:
   - name: branch_name
     description: The name of the branch to delete

--- a/specs/git/set_upstream_branch.yaml
+++ b/specs/git/set_upstream_branch.yaml
@@ -6,7 +6,7 @@ arguments:
     description: The name of the remote
     default_value: origin
   - name: remote_branch
-    description: The name of the remote branch that the local branch should be point to
+    description: The name of the remote branch that the local branch should point to
     default_value: main
   - name: local_branch
     description: The name of the local branch that we want to set

--- a/specs/git/undo_most_recent_git_commit.yaml
+++ b/specs/git/undo_most_recent_git_commit.yaml
@@ -3,7 +3,7 @@ name: Undo most recent git commit
 command: git reset HEAD~
 tags:
   - git
-description: Undos the last git commit while leaving the working tree (the state of the files on disk) untouched.
+description: Undoes the last git commit while leaving the working tree (the state of the files on disk) untouched.
 arguments: []
 source_url: "https://stackoverflow.com/questions/927358/how-do-i-undo-the-most-recent-local-commits-in-git"
 author: Mark Amery

--- a/specs/npm/look_for_all_directories_with_node_modules_and_show_them.yaml
+++ b/specs/npm/look_for_all_directories_with_node_modules_and_show_them.yaml
@@ -3,7 +3,7 @@ name: Finds all node_modules in a folder
 command: find . -name "node_modules" -type d -prune -print | xargs du -chs
 tags:
   - npm
-description: Finds and all node_modules in a folder and displays information about them
+description: Finds all node_modules directories in a folder and displays information about them.
 arguments: []
 source_url: "https://medium.com/@tomlarge/how-to-delete-all-node-modules-folders-from-your-mac-60b5ce9949cf"
 author: Tim Smith

--- a/specs/npm/update_npm_to_the_latest_version.yaml
+++ b/specs/npm/update_npm_to_the_latest_version.yaml
@@ -3,7 +3,7 @@ name: Update NPM to the latest version
 command: npm update -g npm
 tags:
   - npm
-description: Updates npm to the latest version .
+description: Updates npm to the latest version.
 arguments: []
 source_url: "https://stackoverflow.com/questions/6237295/how-can-i-update-nodejs-and-npm-to-the-next-versions"
 author: James


### PR DESCRIPTION
  ## Summary
  Fixes several small typos and wording issues in existing workflow descriptions.

  ## Changes
  - Correct "Undos" to "Undoes"
  - Fix wording in the local git branch deletion workflow
  - Fix wording in the upstream branch workflow argument description
  - Improve wording for the node_modules lookup workflow
  - Remove an extra space in the npm update workflow description

  ## Testing
  - Ran `cargo build`
  - Verified the edited workflows appear in Warp under My Workflows